### PR TITLE
Ship Timestamp

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -160,6 +160,19 @@ rate = fedex.rate(:shipper=>shipper,
                   :shipping_options => shipping_options)
 ```
 
+### ** Getting ALL Shipping Rates for a specific ship date/time **
+
+To find all shipping rates, but for a specific datetime (for examlple, to get around Saturday Pickup Surcharges):
+
+```ruby
+rate = fedex.rate(:ship_timestamp => "2017-05-01T23:59:59-05:00",
+                  :shipper=>shipper,
+                  :recipient => recipient,
+                  :packages => packages,
+                  :smart_post => smart_post,
+                  :shipping_options => shipping_options)
+```
+
 ### ** Get a Transit time **
 ```ruby
 ship = fedex.ship(:shipper=>shipper,

--- a/lib/fedex/request/base.rb
+++ b/lib/fedex/request/base.rb
@@ -52,7 +52,8 @@ module Fedex
         @credentials = credentials
         @shipper, @recipient, @packages, @service_type, @customs_clearance_detail, @smart_post, @debug = options[:shipper], options[:recipient], options[:packages], options[:service_type], options[:customs_clearance_detail], options[:smart_post], options[:debug]
         @debug = ENV['DEBUG'] == 'true'
-        @shipping_options =  options[:shipping_options] ||={}
+        @ship_timestamp = options[:ship_timestamp] || nil
+        @shipping_options = options[:shipping_options] ||={}
         @payment_options = options[:payment_options] ||={}
         @freight_account = options[:freight_account] ||={}
 
@@ -320,6 +321,10 @@ module Fedex
           xml.AncillaryEndorsement weight < 1 ? 'ADDRESS_CORRECTION' : 'FORWARDING_SERVICE' # 'CARRIER_LEAVE_IF_NO_RESPONSE'
           xml.HubId @credentials.mode == "production" ? @smart_post[:hub_id] : '5531' # 5902 (LA)
         }
+      end
+
+      def add_ship_timestamp(xml)
+        xml.ShipTimestamp @ship_timestamp
       end
 
       # Fedex Web Service Api

--- a/lib/fedex/request/rate.rb
+++ b/lib/fedex/request/rate.rb
@@ -35,6 +35,7 @@ module Fedex
       # Add information for shipments
       def add_requested_shipment(xml)
         xml.RequestedShipment{
+          add_ship_timestamp(xml) if @ship_timestamp
           xml.DropoffType @shipping_options[:drop_off_type] ||= "REGULAR_PICKUP"
           xml.ServiceType service_type if service_type
           xml.PackagingType @shipping_options[:packaging_type] ||= "YOUR_PACKAGING"


### PR DESCRIPTION
Add the ability to pass in a ship timestamp for rate requests. Mainly to get around Fedex returning Saturday Pickup Surcharges on express rates when shipping rates are pulled on a Saturday.