### PR TITLE
Electronic Trade Documents

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -411,6 +411,45 @@ service = fedex.service_availability(fedex_service_hash)
 puts service[:options]
 ```
 
+### ** International Shipping **
+
+#### Electronic Trade Documents
+
+For international shipments, documentation can be attached to shipment requests, which are stored electronically on FedEX's servers for easy access during customs processing. To return a Base64 string copy of the requested document, add a non-`nil` value for `:return_copy`.  
+
+```ruby
+etd_shipping_options = {
+  :packaging_type => "YOUR_PACKAGING",
+  :drop_off_type => "REGULAR_PICKUP",
+  :etd => [
+    {:type => "COMMERCIAL_INVOICE", :return_copy => true}
+  ]
+}
+```
+
+The gem contains document specifications for Commercial Invoices, while other documents can be added as hashes through `shipping_document_types` or defined within the gem in `request/document.rb`. Document specifications must be passed through with the required customs clearance detail information:
+
+```ruby
+
+shipping_documents = {
+  :commercial_invoice => true,
+  :shipping_document_types => {
+    # other manually entered document specs
+  }
+}
+
+document = fedex.document(:shipper => shipper,
+                          :recipient => recipient,
+                          :packages => packages,
+                          :service_type => 'INTERNATIONAL_ECONOMY',
+                          :customs_clearance_detail => customs_clearance_detail,
+                          :shipping_options => etd_shipping_options,
+                          :shipping_documents => shipping_documents)
+
+
+```
+
+
 # Services/Options Available
 
 ```ruby

--- a/lib/fedex/request/base.rb
+++ b/lib/fedex/request/base.rb
@@ -165,10 +165,16 @@ module Fedex
         }
       end
 
-      # Add shipping charges to xml request
+      # Add shipping charges to xml request - wrapper for Payor/PaymentType nodes
       def add_shipping_charges_payment(xml)
         xml.ShippingChargesPayment{
-          xml.PaymentType @payment_options[:type] || "SENDER"
+          add_payment_and_payor(xml)
+        }
+      end
+
+      # Add payor Node
+      def add_payment_and_payor(xml)
+        xml.PaymentType @payment_options[:type] || "SENDER"
           xml.Payor{
             if service[:version].to_i >= Fedex::API_VERSION.to_i
               xml.ResponsibleParty {
@@ -184,7 +190,6 @@ module Fedex
               xml.CountryCode @payment_options[:country_code] || @shipper[:country_code]
             end
           }
-        }
       end
 
       # Add Master Tracking Id (for MPS Shipping Labels, this is required when requesting labels 2 through n)
@@ -307,8 +312,14 @@ module Fedex
       # Add customs clearance(for international shipments)
       def add_customs_clearance(xml)
         xml.CustomsClearanceDetail{
+          xml.DutiesPayment{
+            add_payment_and_payor(xml)
+          }
+          # Mid step - Include Payor, not rest of hash
           hash_to_xml(xml, @customs_clearance_detail)
         }
+
+        # Customs clearance needs to re-add the payor node in the xml
       end
 
       # Smart Post

--- a/lib/fedex/request/base.rb
+++ b/lib/fedex/request/base.rb
@@ -312,14 +312,14 @@ module Fedex
       # Add customs clearance(for international shipments)
       def add_customs_clearance(xml)
         xml.CustomsClearanceDetail{
+          # Add DutiesPayment node w/ Payor info
           xml.DutiesPayment{
             add_payment_and_payor(xml)
           }
-          # Mid step - Include Payor, not rest of hash
+          
+          # Attach remainder of CCD from input hash
           hash_to_xml(xml, @customs_clearance_detail)
         }
-
-        # Customs clearance needs to re-add the payor node in the xml
       end
 
       # Smart Post

--- a/lib/fedex/request/document.rb
+++ b/lib/fedex/request/document.rb
@@ -14,8 +14,11 @@ module Fedex
 
       def add_custom_components(xml)
         super
-
-        add_shipping_document(xml) if @shipping_document
+        if @shipping_document == "COMMERCIAL_INVOICE"
+          add_commercial_invoice(xml)
+        else
+          add_shipping_document(xml) if @shipping_document
+        end
       end
 
       private
@@ -27,6 +30,23 @@ module Fedex
             xml.ShippingDocumentTypes type
           end
           hash_to_xml(xml, @shipping_document.reject{ |k| k == :shipping_document_types})
+        }
+      end
+
+      # If additional types of documents are needed, individual functions
+      # can go here. Basically, these are hardcoded required values, and
+      # shouldn't be in Blackbox core code just because the fedex gem and
+      # API are quirky and bad
+      #  - ajb, 21 Apr 2017
+      def add_commercial_invoice(xml)
+        xml.ShippingDocumentSpecification{
+          xml.ShippingDocumentTypes "COMMERCIAL_INVOICE"
+          xml.CommercialInvoiceDetail {
+            xml.Format {
+              xml.ImageType "PDF"
+              xml.StockType "PAPER_LETTER"
+            }
+          }
         }
       end
 

--- a/lib/fedex/request/document.rb
+++ b/lib/fedex/request/document.rb
@@ -8,16 +8,17 @@ module Fedex
       def initialize(credentials, options={})
         super(credentials, options)
 
-        @shipping_document = options[:shipping_document]
+        @shipping_documents = options[:shipping_documents]
         @filenames = options.fetch(:filenames) { {} }
       end
 
+
       def add_custom_components(xml)
         super
-        if @shipping_document == "COMMERCIAL_INVOICE"
+        if @shipping_documents.include? "COMMERCIAL_INVOICE"
           add_commercial_invoice(xml)
         else
-          add_shipping_document(xml) if @shipping_document
+          add_shipping_document(xml) if @shipping_documents[:shipping_document_types]
         end
       end
 
@@ -26,10 +27,10 @@ module Fedex
       # Add shipping document specification
       def add_shipping_document(xml)
         xml.ShippingDocumentSpecification{
-          Array(@shipping_document[:shipping_document_types]).each do |type|
+          Array(@shipping_documents[:shipping_document_types]).each do |type|
             xml.ShippingDocumentTypes type
           end
-          hash_to_xml(xml, @shipping_document.reject{ |k| k == :shipping_document_types})
+          hash_to_xml(xml, @shipping_documents.reject{ |k| k == :shipping_document_types})
         }
       end
 

--- a/lib/fedex/request/document.rb
+++ b/lib/fedex/request/document.rb
@@ -15,7 +15,7 @@ module Fedex
 
       def add_custom_components(xml)
         super
-        if @shipping_documents.include? "COMMERCIAL_INVOICE"
+        if @shipping_documents[:commercial_invoice]
           add_commercial_invoice(xml)
         else
           add_shipping_document(xml) if @shipping_documents[:shipping_document_types]

--- a/lib/fedex/request/shipment.rb
+++ b/lib/fedex/request/shipment.rb
@@ -49,7 +49,7 @@ module Fedex
           add_shipper(xml)
           add_recipient(xml)
           add_shipping_charges_payment(xml)
-          add_special_services(xml) if @shipping_options[:return_reason] || @shipping_options[:cod]
+          add_special_services(xml) if @shipping_options[:return_reason] || @shipping_options[:cod] || @shipping_options[:etd]
           add_customs_clearance(xml) if @customs_clearance_detail
           add_smart_post(xml) if @smart_post
           add_custom_components(xml)
@@ -101,6 +101,12 @@ module Fedex
                 xml.Amount @shipping_options[:cod][:amount] if @shipping_options[:cod][:amount]
               }
               xml.CollectionType @shipping_options[:cod][:collection_type] if @shipping_options[:cod][:collection_type]
+            }
+          end
+          if @shipping_options[:etd]
+            xml.SpecialServiceTypes "ELECTRONIC_TRADE_DOCUMENTS"
+            xml.EtdDetail {
+              xml.RequestedDocumentCopies @shipping_options[:etd]
             }
           end
         }

--- a/lib/fedex/request/shipment.rb
+++ b/lib/fedex/request/shipment.rb
@@ -106,7 +106,9 @@ module Fedex
           if @shipping_options[:etd]
             xml.SpecialServiceTypes "ELECTRONIC_TRADE_DOCUMENTS"
             xml.EtdDetail {
-              xml.RequestedDocumentCopies @shipping_options[:etd]
+              Array(@shipping_options[:etd]).each do |type|
+                xml.RequestedDocumentCopies type[:type] if type[:return_copy]
+              end
             }
           end
         }


### PR DESCRIPTION
See Readme diff for implementation changes.

This PR adds simplified inputs for generating Commerical Invoices, returning them as base64 strings, and attaching them to an order as ETDs.

There's some additional tweaks, specifically to payment information, to make inputs DRYer. If we want the ability to have different accounts pay for shipment and duties, some logic will need to be added around this component. 